### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -2,27 +2,33 @@ const express = require('express');
 const app = express();
 const port = 3000;
 
-// Fake data for the activity feed
-const activityFeed = [
+// Fake data for tasks
+const tasks = [
   {
-    id: 1000,
-    title: 'New Photo Uploaded',
-    body: 'Alice uploaded a new photo to her album.'
+    id: 1,
+    description: 'Complete monthly financial report'
   },
   {
-    id: 2000,
-    title: 'Comment on Post',
-    body: "Bob commented on Charlie's post."
+    id: 2,
+    description: 'Plan team building activity'
   },
   {
-    id: 13,
-    title: 'Status Update',
-    body: 'Charlie updated their status: "Excited about the new project!"'
+    id: 3,
+    description: 'Update project documentation'
   }
 ];
 
-app.get('/feed', (req, res) => {
-  res.json(activityFeed);
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
### TL;DR

Replaced activity feed with a task search endpoint.

### What changed?

- Replaced the mock `activityFeed` data with `tasks` data that includes task IDs and descriptions
- Changed the API endpoint from `/feed` to `/search`
- Implemented search functionality that filters tasks based on a query parameter

### How to test?

1. Start the server: `node server.js`
2. Test the search endpoint with various queries:
   - `GET /search` - Returns all tasks
   - `GET /search?query=report` - Returns tasks containing "report"
   - `GET /search?query=team` - Returns tasks containing "team"

### Why make this change?

This change shifts the application's focus from a social media-like activity feed to a task management system with search capabilities, providing users with the ability to find specific tasks based on keywords.